### PR TITLE
Rename constant INVALID_PATH_ID to INVALID_GPS_PATH_ID to avoid conflict with open.mp Pawn lib

### DIFF
--- a/GPS.inc
+++ b/GPS.inc
@@ -9,7 +9,7 @@
 
 
 const MapNode:INVALID_MAP_NODE_ID = MapNode:-1;
-const Path:INVALID_PATH_ID = Path:-1;
+const Path:INVALID_GPS_PATH_ID = Path:-1;
 const Connection:INVALID_CONNECTION_ID = Connection:-1;
 
 enum _:GPS_ERROR 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Include in your code and begin using the library:
 
 `FindPathThreaded(MapNode:source, MapNode:target, const callback[], const format[] = "", {Float, _}:...)`
 
-* If both of the specified map nodes are valid, returns `GPS_ERROR_NONE` and tries to find a path from `source` to `target`. After pathfinding is finished, calls the specified callback and passes the path ID (could be `INVALID_PATH_ID` if pathfinding fails) and the specified arguments to it.
+* If both of the specified map nodes are valid, returns `GPS_ERROR_NONE` and tries to find a path from `source` to `target`. After pathfinding is finished, calls the specified callback and passes the path ID (could be `INVALID_GPS_PATH_ID` if pathfinding fails) and the specified arguments to it.
 
 `Task:FindPathAsync(MapNode:source, MapNode:target)`
 


### PR DESCRIPTION
The latest version of the open.mp standard library (omp-stdlib) introduced a constant named INVALID_PATH_ID (https://github.com/openmultiplayer/omp-stdlib/blob/master/omp_npc.inc#L46) for the NPC component.

This causes a redefinition conflict with the identically named constant in GPS.inc, which triggers the compiler error **error 020: invalid symbol name ""**.

This PR simply renames the constant to INVALID_GPS_PATH_ID to avoid the namespace collision in the Pawn API.